### PR TITLE
Intel shader segfault

### DIFF
--- a/resources/shaders/shader.frag
+++ b/resources/shaders/shader.frag
@@ -8,8 +8,8 @@ in vec4 directional_light_space_pos;
 
 out vec4 color;
 
-const int MAX_POINT_LIGHTS = 8;
-const int MAX_SPOT_LIGHTS = 8;
+const int MAX_POINT_LIGHTS = 14;
+const int MAX_SPOT_LIGHTS = 14;
 
 struct Light {
 	vec3 color;
@@ -36,10 +36,10 @@ struct SpotLight {
 	float edge;
 };
 
-// struct OmniShadowMap {
-// 	samplerCube shadow_map;
-// 	float far_plane;
-// };
+struct OmniShadowMap {
+	samplerCube shadow_map;
+	float far_plane;
+};
 
 struct Material {
 	float specularIntensity;
@@ -59,10 +59,7 @@ uniform SpotLight spotLights[MAX_SPOT_LIGHTS];
 uniform sampler2D theTexture;
 uniform sampler2D directional_shadow_map;
 uniform sampler2D detailmap;
-
-// uniform OmniShadowMap omni_shadow_maps[MAX_POINT_LIGHTS + MAX_SPOT_LIGHTS];
-uniform samplerCube omni_shadow_maps[MAX_POINT_LIGHTS + MAX_SPOT_LIGHTS];
-uniform float omni_far_planes[MAX_POINT_LIGHTS + MAX_SPOT_LIGHTS];
+uniform OmniShadowMap omni_shadow_maps[MAX_POINT_LIGHTS + MAX_SPOT_LIGHTS];
 
 uniform Material material;
 
@@ -119,14 +116,15 @@ float calc_omni_shadow_factor(PointLight light, int shadow_index) {
 
 	float view_distance = length(eyePosition - fragPos);
 	float disk_radius =
-	    (1.0 + (view_distance / omni_far_planes[shadow_index])) / 25.0;
+	    (1.0 + (view_distance / omni_shadow_maps[shadow_index].far_plane)) /
+	    25.0;
 
 	for (int i = 0; i < samples; ++i) {
 		float closest =
-		    texture(omni_shadow_maps[shadow_index],
+		    texture(omni_shadow_maps[shadow_index].shadow_map,
 		            frag_to_light + sampleOffsetDirections[i] * disk_radius)
 		        .r;
-		closest *= omni_far_planes[shadow_index];
+		closest *= omni_shadow_maps[shadow_index].far_plane;
 
 		if (current - bias > closest) {
 			shadow += 1.0;

--- a/src/CommonValues.hpp
+++ b/src/CommonValues.hpp
@@ -1,4 +1,4 @@
 #pragma once
 
-constexpr size_t MAX_POINT_LIGHTS = 8;
-constexpr size_t MAX_SPOT_LIGHTS = 8;
+constexpr size_t MAX_POINT_LIGHTS = 14;
+constexpr size_t MAX_SPOT_LIGHTS = 14;

--- a/src/View/Renderer/OpenGL/Objects/Shader.cpp
+++ b/src/View/Renderer/OpenGL/Objects/Shader.cpp
@@ -353,11 +353,12 @@ void Shader::CompileProgram() {
 	for (size_t i = 0; i < MAX_POINT_LIGHTS + MAX_SPOT_LIGHTS; ++i) {
 		char locBuff[100] = {'\0'};
 
-		snprintf(locBuff, sizeof(locBuff), "omni_shadow_maps[%d]", i);
+		snprintf(locBuff, sizeof(locBuff), "omni_shadow_maps[%d].shadow_map",
+		         i);
 		uniformOmniShadowMap[i].shadowMap =
 		    glGetUniformLocation(m_shaderID, locBuff);
 
-		snprintf(locBuff, sizeof(locBuff), "omni_far_planes[%d]", i);
+		snprintf(locBuff, sizeof(locBuff), "omni_shadow_maps[%d].far_plane", i);
 		uniformOmniShadowMap[i].farPlane =
 		    glGetUniformLocation(m_shaderID, locBuff);
 	}


### PR DESCRIPTION
This is a fix to issue #108.

The issue was that only 32 available sampler units were in OpenGL, so exceeding that will segfault Intel drivers.

There are 3-4 that are already being used other than for the omnidirectional shadow maps, so it needs to be decreased to fit within 32.