### PR TITLE
Setup core chat functionality with ECS

### DIFF
--- a/resources/game/ECSScene/scripts/network_chat_read_menu.lua
+++ b/resources/game/ECSScene/scripts/network_chat_read_menu.lua
@@ -1,0 +1,14 @@
+gui_setWindowSize(300, 300, 2)
+gui_setWindowPos(300, 500, 1)
+
+gui_begin("Chat reader")
+	gui_text("Chat Window")
+	if chatLog == nil then
+		chatLog = "This is the beginning of the chat log\n"
+	end
+	if network_get_message() ~= " " then
+		chatLog = chatLog .. network_get_message()
+	end
+	gui_text(chatLog)
+
+gui_end()

--- a/resources/game/ECSScene/scripts/network_chat_send_menu.lua
+++ b/resources/game/ECSScene/scripts/network_chat_send_menu.lua
@@ -1,0 +1,22 @@
+gui_setWindowSize(300, 300, 2)
+gui_setWindowPos(0, 500, 1)
+
+gui_begin("Chat sender")
+
+local message = gui_luaInputText("Message: ")
+if network_return_message() ~= nil then
+	savedMessage = network_return_message()
+else
+	savedMessage = ""
+end
+gui_text(savedMessage)
+local send = gui_button("Send", 300, 50)
+
+
+network_retain_message(message)
+
+if send then
+	network_send_message()
+end
+
+gui_end()

--- a/resources/game/ECSScene/scripts/network_menu.lua
+++ b/resources/game/ECSScene/scripts/network_menu.lua
@@ -1,0 +1,49 @@
+gui_setWindowSize(300, 300, 2)
+gui_setWindowPos(500, 0, 1)
+
+gui_begin("Network Menu")
+
+gui_text("--This is the network test menu--")
+local Init = gui_button("Init", 150, 50)
+local Start = gui_button("Start Server", 150, 50)
+local ServerIP = gui_luaInputText("Enter Server IP: ")
+if network_return_IP() ~= nil then
+	fullIP = network_return_IP()
+else
+	fullIP = ""
+end
+gui_text(fullIP)
+local Connect = gui_button("Connect", 150, 50)
+--local Exit = gui_button("Exit Menu", 150, 50)
+
+if (network_connection_status() == true) then
+		gui_text("You are connected!")
+	else
+		gui_text("You are not connected")
+end
+
+gui_end()
+
+network_retain_IP(ServerIP)
+
+if (Init) then
+	create_network_manager(true)
+end
+
+
+if(Start) then
+	start_server(true)
+end
+
+if(Connect) then
+	network_client_connect()
+end
+
+if(network_connection_status()) then
+	dofile "game/ECSScene/scripts/network_chat_send_menu.lua"
+	dofile "game/ECSScene/scripts/network_chat_read_menu.lua"
+end
+
+if(Time.is_paused()==false) then
+	network_terminate()
+end

--- a/resources/game/ECSScene/scripts/player_script.lua
+++ b/resources/game/ECSScene/scripts/player_script.lua
@@ -69,5 +69,6 @@ function update(ecs, entity)
 
 	if (Time.is_paused()) then
 		dofile "game/ECSScene/scripts/pause_menu.lua"
+		dofile "game/ECSScene/scripts/network_menu.lua"
 	end
 end

--- a/src/Scene/ECSScene.cpp
+++ b/src/Scene/ECSScene.cpp
@@ -5,6 +5,7 @@
 #include "Controller/ECSGameAssetFactory.hpp"
 #include "Controller/Audio/Audio.hpp"
 #include "Controller/ECS/System.hpp"
+#include "Controller/Networking/NetworkAccess.h"
 
 ECSScene::ECSScene(const std::string& master_lua_script)
     : Scene(master_lua_script) {}
@@ -24,6 +25,7 @@ void ECSScene::mouse_controls(double xpos, double ypos) {
 void ECSScene::update(double delta_time) {
 	ecs_.update(delta_time);
 	Audio::get_instance().update_listener();
+	NetworkAccess::networkUpdate();
 }
 
 void ECSScene::fixed_update(double delta_time) {


### PR DESCRIPTION
- Created basic chat menus for ECS, which can:
+ Initialise and start server
+ Connect to server
+ Send and Receive chat messages (when connected to a server/is a server)
+ Windows automatically close (and server is terminated) when the game is unpaused (using the button)
- GUI functionality currently tied to the pause menu
- Added NetworkAccess::networkUpdate() to ECSScene Update() (required for network manager to update)